### PR TITLE
Fixed Typo in evt_stats.h

### DIFF
--- a/test/util/evt_stats.h
+++ b/test/util/evt_stats.h
@@ -55,7 +55,7 @@ class EvtStatsT {
       const evt_id_t id = e.first;
       const char* label = get_label(id);
       std::ostringstream oss;
-      oss << index << ",\"" << label << "\"," << e.second.count << "," << (uint64_t)(e.second.avr) << ',' << (uint64_t)(e.second.count * e.second.avr);
+      oss << index << ",\"" << label << "\"," << e.second.count << "," << (uint64_t)(e.second.avr) << "," << (uint64_t)(e.second.count * e.second.avr);
       fprintf(fdes_, "%s\n", oss.str().c_str());
       index += 1;
     }


### PR DESCRIPTION
This typo is affecting the generation of the stats if flags like ROCP_STATS_OPT were used.